### PR TITLE
Support multibyte char for Windows.

### DIFF
--- a/spec/clipboard_spec.rb
+++ b/spec/clipboard_spec.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Please note: cannot test, if it really accesses your platform clipboard.
 
 require File.expand_path('spec/spec_helper')
@@ -16,6 +17,12 @@ describe Clipboard do
   it "can copy & paste" do
     Clipboard.copy("FOO\nBAR")
     Clipboard.paste.should == "FOO\nBAR"
+  end
+
+  it "can copy & paste with multibyte char" do
+    Encoding.default_external = "utf-8"
+    Clipboard.copy("日本語")
+    Clipboard.paste.should == "日本語"
   end
 
   it "returns data on copy" do


### PR DESCRIPTION
I wrote a patch because it fails this test case.

  it "can copy & paste with multibyte char" do
    Encoding.default_external = "utf-8"
    Clipboard.copy("日本語")
    Clipboard.paste.should == "日本語"
  end

Failure/Error: Clipboard.copy("日本語")
Encoding::InvalidByteSequenceError:
  incomplete "\x00" on UTF-16LE
