### PR TITLE
Fix copy with xsel.

### DIFF
--- a/lib/clipboard/linux.rb
+++ b/lib/clipboard/linux.rb
@@ -13,7 +13,7 @@ module Clipboard::Linux
     ReadCommand  = 'xclip -o'
     Selection    = proc{|x| "-selection #{x}"}
   elsif system('which xsel >/dev/null 2>&1')
-    WriteCommand = 'xsel'
+    WriteCommand = 'xsel -i'
     ReadCommand  = 'xsel -o'
     Selection    = {'clipboard' => '-b', 'primary' => '-p', 'secondary' => '-s'}
   else


### PR DESCRIPTION
xsel sometimes does read the password from standard input if -i is not
given, but often the process gets an EPIPE.  Specifically provide the -i
option so that xsel waits on standard input to avoid this.

I tested this with xsel 1.2.0.  The existing xclip integration seems to work fine.
