### PR TITLE
Remove post install message

### DIFF
--- a/clipboard.gemspec
+++ b/clipboard.gemspec
@@ -18,14 +18,4 @@ Gem::Specification.new do |s|
   s.files = Dir.glob(%w[{lib,spec}/**/*.rb [A-Z]* [A-Z]*.rdoc]) + %w{clipboard.gemspec .gemtest}
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>=2'
-
-  len = s.homepage.size
-  s.post_install_message = \
-   ("       ┌── " + "info ".ljust(len-2,'%')            + "─┐\n" +
-    " J-_-L │ "   + s.homepage                          + " │\n" +
-    "       ├── " + "usage ".ljust(len-2,'%')           + "─┤\n" +
-    "       │ "   + "require 'clipboard'".ljust(len,' ')     + " │\n" +
-    "       │ "   + "Clipboard.copy '42'".ljust(len,' ')     + " │\n" +
-    "       │ "   + "Clipboard.paste #=> 42".ljust(len,' ')  + " │\n" +
-    "       └─"   + '─'*len                             + "─┘").gsub('%', '─') # 1.8 workaround
 end


### PR DESCRIPTION
Clipboard provides an interface that is likely to be used by other gems. If you're developing, you've likely found the github page and know how to use it (and it's a super simple interface).

A user that isn't familiar with gems and post install messages might be confused if they install a gem that has Clipboard as a dependency, the message isn't useful to them but it's usually the most obvious output shown during the gem install process.

It has caused our users some confusion, so we've removed it. We'd rather use the official version, not a fork, no worries if you'd rather not remove it.
