### PR TITLE
linux: Replace calls to `which` with native check

### DIFF
--- a/lib/clipboard/linux.rb
+++ b/lib/clipboard/linux.rb
@@ -1,5 +1,7 @@
 require 'open3'
 
+require_relative 'utils'
+
 module Clipboard
   module Linux
     extend self
@@ -7,11 +9,11 @@ module Clipboard
     CLIPBOARDS = %w[clipboard primary secondary].freeze
 
     # check which backend to use
-    if system('which xclip >/dev/null 2>&1')
+    if Utils.installed?('xclip')
       WriteCommand = 'xclip'.freeze
       ReadCommand  = 'xclip -o'.freeze
       Selection    = proc{ |x| "-selection #{x}" }.freeze
-    elsif system('which xsel >/dev/null 2>&1')
+    elsif Utils.installed?('xsel')
       WriteCommand = 'xsel -i'.freeze
       ReadCommand  = 'xsel -o'.freeze
       Selection    = { 'clipboard' => '-b', 'primary' => '-p', 'secondary' => '-s' }.freeze

--- a/lib/clipboard/utils.rb
+++ b/lib/clipboard/utils.rb
@@ -1,0 +1,11 @@
+module Clipboard
+  module Utils
+    extend self
+
+    def installed?(cmd)
+      ENV['PATH'].split(::File::PATH_SEPARATOR).any? do |path|
+        ::File.executable?(::File.join(path, cmd))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi there,

This PR just replaces calls to `which` with a new method (`Utils.installed?`) that performs an equivalent check in pure Ruby. This is a good bit faster, as it doesn't create any additional child processes.

I added `installed?` under a new `Utils` module, but please let me know if you'd prefer a different location.

Thanks for all the hard work on `clipboard` -- it's been a pleasure to use in my projects!

Best,
William