### PR TITLE
Use system File class instead of Clipboard::File.

### DIFF
--- a/lib/clipboard/cygwin.rb
+++ b/lib/clipboard/cygwin.rb
@@ -5,11 +5,11 @@ module Clipboard
     extend self
 
     def paste(_ = nil)
-      File.read("/dev/clipboard")
+      ::File.read("/dev/clipboard")
     end
 
     def copy(data)
-      File.open("/dev/clipboard", "w"){ |f| f.write(data) }
+      ::File.open("/dev/clipboard", "w"){ |f| f.write(data) }
       paste
     end
 


### PR DESCRIPTION
Hi,

I found Clipboard.copy() and paste() fail in Cygwin with the following error.

[1] pry(main)> Clipboard.copy 'a'
NoMethodError: private method `open' called for Clipboard::File:Module
from /home/Srodlo/.rbenv/versions/2.6.0/lib/ruby/gems/2.6.0/gems/clipboard-1.3.2/lib/clipboard/cygwin.rb:12:in `copy'

The patch works on my environment.
Thank you,
