### PR TITLE
do not crash on ruby 2.1

### DIFF
--- a/lib/clipboard.rb
+++ b/lib/clipboard.rb
@@ -35,7 +35,7 @@ module Clipboard
     # Running additional check to detect if running in Microsoft WSL
     if os == :Linux
       require "etc"
-      if Etc.uname[:release] =~ /Microsoft/
+      if Etc.respond_to?(:uname) && Etc.uname[:release] =~ /Microsoft/ # uname was added in ruby 2.2
         os = :Wsl
       end
     end


### PR DESCRIPTION
was caused by https://github.com/janlelis/clipboard/commit/1d792b1e909d4949186e50cd1ed397d19152a3be + not having CI for old ruby version :(
@janlelis