### PR TITLE
Fix missing String#+@ method on Ruby <2.3

### DIFF
--- a/lib/clipboard/windows.rb
+++ b/lib/clipboard/windows.rb
@@ -42,7 +42,7 @@ module Clipboard
 
     # see http://www.codeproject.com/KB/clipboard/archerclipboard1.aspx
     def paste(_ = nil)
-      data = +""
+      data = "".dup
       if 0 != User32.open( 0 )
         hclip = User32.get( CF_UNICODETEXT )
         if hclip && 0 != hclip


### PR DESCRIPTION
The unary plus method on `String` was only added in Ruby 2.3, so trying to use the Windows clipboard implementation on an earlier version (in my case, Ruby 2.2) raises an exception.

This replaces the use of the unary plus method with `#dup`, which should be equivalent for this string literal.