### PR TITLE
Fixes #42 by correcting User32 function signatures

### DIFF
--- a/lib/clipboard/windows.rb
+++ b/lib/clipboard/windows.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "utils"
+require_relative 'utils'
 
 module Clipboard
   module Windows
@@ -19,14 +19,14 @@ module Clipboard
 
     module User32
       extend FFI::Library
-      ffi_lib "user32"
+      ffi_lib 'user32'
       ffi_convention :stdcall
 
-      attach_function :open,  :OpenClipboard,    [ :long ], :long
-      attach_function :close, :CloseClipboard,   [       ], :long
-      attach_function :empty, :EmptyClipboard,   [       ], :long
-      attach_function :get,   :GetClipboardData, [ :long ], :long
-      attach_function :set,   :SetClipboardData, [ :long, :long ], :long
+      attach_function :open,  :OpenClipboard,    [ :pointer ], :bool
+      attach_function :close, :CloseClipboard,   [       ], :bool
+      attach_function :empty, :EmptyClipboard,   [       ], :bool
+      attach_function :get,   :GetClipboardData, [ :long ], :pointer
+      attach_function :set,   :SetClipboardData, [ :long, :pointer ], :pointer
     end
 
     module Kernel32
@@ -34,53 +34,55 @@ module Clipboard
       ffi_lib 'kernel32'
       ffi_convention :stdcall
 
-      attach_function :lock,   :GlobalLock,   [ :long ], :pointer
-      attach_function :unlock, :GlobalUnlock, [ :long ], :long
-      attach_function :size,   :GlobalSize,   [ :long ], :long
-      attach_function :alloc,  :GlobalAlloc,  [ :long, :long ], :long
+      attach_function :lock,   :GlobalLock,   [ :pointer ], :pointer
+      attach_function :unlock, :GlobalUnlock, [ :pointer ], :bool
+      attach_function :size,   :GlobalSize,   [ :pointer ], :long
+      attach_function :alloc,  :GlobalAlloc,  [ :long, :long ], :pointer
     end
 
     # see http://www.codeproject.com/KB/clipboard/archerclipboard1.aspx
     def paste(_ = nil)
-      data = "".dup
-      if 0 != User32.open( 0 )
+      data = String.new
+      if User32.open(nil)
         hclip = User32.get( CF_UNICODETEXT )
-        if hclip && 0 != hclip
+        unless hclip.null?
           pointer_to_data = Kernel32.lock( hclip )
           # Windows Unicode is ended by two null bytes, so get the whole string
           size = Kernel32.size( hclip )
           data << pointer_to_data.get_bytes( 0, size - 2 )
-          data.force_encoding("UTF-16LE")
+          data.force_encoding(Encoding::UTF_16LE)
           Kernel32.unlock( hclip )
         end
-        User32.close( )
       end
       data
+    ensure
+      User32.close
     end
 
     def clear
-      if 0 != User32.open( 0 )
-        User32.empty( )
-        User32.close( )
-      end
+      User32.empty if User32.open(nil)
       paste
+    ensure
+      User32.close
     end
 
     def copy(data_to_copy)
-      if 0 != User32.open( 0 )
-        User32.empty( )
-        data = data_to_copy.encode("UTF-16LE") # TODO: catch bad encodings
+      if User32.open(nil)
+        User32.empty
+        data = data_to_copy.encode(Encoding::UTF_16LE) # TODO: catch bad encodings
         data << 0
         handler = Kernel32.alloc( GMEM_MOVEABLE, data.bytesize )
         pointer_to_data = Kernel32.lock( handler )
         pointer_to_data.put_bytes( 0, data, 0, data.bytesize )
         Kernel32.unlock( handler )
         User32.set( CF_UNICODETEXT, handler )
-        User32.close( )
+        data_to_copy
       else # don't touch anything
         Utils.popen "clip", data_to_copy # depends on clip (available by default since Vista)
+        paste
       end
-      paste
+    ensure
+      User32.close
     end
   end
 end

--- a/spec/clipboard_spec.rb
+++ b/spec/clipboard_spec.rb
@@ -17,13 +17,13 @@ describe Clipboard do
 
   it "can copy & paste" do
     Clipboard.copy("FOO\nBAR")
-    expect( Clipboard.paste ).to eq "FOO\nBAR"
+    expect( Clipboard.paste.encode(Encoding::UTF_8) ).to eq "FOO\nBAR"
   end
 
   it "can copy & paste with multibyte char" do
     Encoding.default_external = "utf-8"
     Clipboard.copy("日本語")
-    expect( Clipboard.paste ).to eq "日本語"
+    expect( Clipboard.paste.encode(Encoding::UTF_8) ).to eq "日本語"
   end
 
   it "returns data on copy" do
@@ -33,7 +33,7 @@ describe Clipboard do
   it "can clear" do
     Clipboard.copy('xxx')
     Clipboard.clear
-    expect( Clipboard.paste ).to eq ''
+    expect( Clipboard.paste.encode(Encoding::UTF_8) ).to eq ''
   end
 
   describe "when included" do
@@ -44,9 +44,9 @@ describe Clipboard do
     it "can copy & paste & clear" do
       a = A.new
       expect( a.send(:copy, "XXX") ).to eq 'XXX'
-      expect( a.send(:paste) ).to eq "XXX"
+      expect( a.send(:paste).encode(Encoding::UTF_8) ).to eq "XXX"
       a.send(:clear)
-      expect( a.send(:paste) ).to eq ''
+      expect( a.send(:paste).encode(Encoding::UTF_8) ).to eq ''
     end
   end
 


### PR DESCRIPTION
The User32 functions types were inconsistent, for example:
* long -> pointer
* long -> bool

In order to keep consistency in the tests I'm also encoding the results as UTF-8