### PR TITLE
Fixes #44 by adding support for wayland

### DIFF
--- a/lib/clipboard.rb
+++ b/lib/clipboard.rb
@@ -10,12 +10,13 @@ module Clipboard
   end
 
   unless defined? Ocra # see gh#9
-    autoload :Linux,   'clipboard/linux'
-    autoload :Mac,     'clipboard/mac'
-    autoload :Java,    'clipboard/java'
-    autoload :Cygwin,  'clipboard/cygwin'
-    autoload :Wsl,     'clipboard/wsl'
-    autoload :Gtk,     'clipboard/gtk'
+    autoload :Linux,          'clipboard/linux'
+    autoload :LinuxWayland,   'clipboard/linux_wayland'
+    autoload :Mac,            'clipboard/mac'
+    autoload :Java,           'clipboard/java'
+    autoload :Cygwin,         'clipboard/cygwin'
+    autoload :Wsl,            'clipboard/wsl'
+    autoload :Gtk,            'clipboard/gtk'
   end
   autoload :Windows, 'clipboard/windows'
   autoload :File,    'clipboard/file'
@@ -32,11 +33,15 @@ module Clipboard
       raise ClipboardLoadError, "Your OS(#{ RbConfig::CONFIG['host_os'] }) is not supported, using file-based (fake) clipboard"
     end
 
-    # Running additional check to detect if running in Microsoft WSL
+    # Running additional check to detect if
+    # running in Microsoft WSL
+    # or wayland
     if os == :Linux
       require "etc"
       if Etc.respond_to?(:uname) && Etc.uname[:release] =~ /Microsoft/ # uname was added in ruby 2.2
         os = :Wsl
+      elsif ENV["XDG_SESSION_TYPE"] == "wayland"
+        os = :LinuxWayland
       end
     end
 

--- a/lib/clipboard/linux_wayland.rb
+++ b/lib/clipboard/linux_wayland.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "utils"
+
+module Clipboard
+  module LinuxWayland
+    extend self
+
+    def paste(_ = nil)
+      `wl-paste`
+    end
+
+    def copy(data)
+      Utils.popen "wl-copy", data
+      paste
+    end
+
+    def clear
+      `wl-copy -c`
+    end
+  end
+end


### PR DESCRIPTION
Solution for #44 by adding a new backend for wayland based linux window managers which depends on wl-copy and wl-paste.

it might be smart to rename the `Linux` backend to `LinuxX11` as its implementation only works on x11, however this is a breaking change so it should probably wait to the next major release
